### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:edit, :show, :update]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
   before_action :move_to_index, only: [:edit]
 
   def index
@@ -34,6 +34,12 @@ class ItemsController < ApplicationController
       render :edit
     end
   end
+
+  def destroy
+    @item.destroy
+    redirect_to root_path
+  end
+
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
   end
 
   def update
-   if @item.update(item_params)
+    if @item.update(item_params)
 
       redirect_to action: :show
     else
@@ -39,7 +39,6 @@ class ItemsController < ApplicationController
     @item.destroy
     redirect_to root_path
   end
-
 
   private
 
@@ -55,6 +54,4 @@ class ItemsController < ApplicationController
   def move_to_index
     redirect_to action: :index unless current_user.id == @item.user_id
   end
-
-  
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
   before_action :set_item, only: [:edit, :show, :update, :destroy]
-  before_action :move_to_index, only: [:edit]
+  before_action :move_to_index, only: [:edit, :destroy]
 
   def index
     @items = Item.order('created_at DESC')

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if current_user.id == @item.user_id %>
     <%= link_to "商品の編集",  edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
     
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end


### PR DESCRIPTION
#What
商品削除ボタンの作成
#Why
商品削除機能を実装するため

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画[
gyazo.com/390db54edf1aa1ddc9478f02f4e0ae32